### PR TITLE
Fix exception "cannot read property payload from undefined"

### DIFF
--- a/src/base/convert.coffee
+++ b/src/base/convert.coffee
@@ -10,8 +10,12 @@ exports.extractValue = (callback) ->
 			else
 				messageToUse = messages
 			debug "message to use",messageToUse
-			result = messageToUse[0].payload.replace(new RegExp(" ", "g"), "")
-			callback(error, result)
+			if messages.length > 1
+				result = messageToUse[0].payload.replace(new RegExp(" ", "g"), "")
+				callback(error, result)
+			else
+				callback
+					msg: "No usable messages received, but no error returned."
 		else
 			callback(error)
 

--- a/src/base/convert.coffee
+++ b/src/base/convert.coffee
@@ -10,7 +10,7 @@ exports.extractValue = (callback) ->
 			else
 				messageToUse = messages
 			debug "message to use",messageToUse
-			if messages.length > 1
+			if messageToUse.length > 0
 				result = messageToUse[0].payload.replace(new RegExp(" ", "g"), "")
 				callback(error, result)
 			else


### PR DESCRIPTION
Unfortunatly I cannot verfy if my coffee syntax is right, but I tried hard to code it right...
I changed my copy in build, which I didn't upload here, since "build" is only the result of coffee.

Without this fix, users randomly reported the given exception. Checking the code I found, that only return of an explicit error or the presence of more than 1 messages is being handled. Return of 0 messages without error would have lead to the exception.

You might consider to increase the version number after applying the patch ;)