### PR TITLE
Fix write command to send payload length

### DIFF
--- a/src/base/communication.coffee
+++ b/src/base/communication.coffee
@@ -42,7 +42,7 @@ sendCommandToSocket = (options, socket, callback) ->
 
 	socket.connect options.port, options.server, ->
 		debug "Sending",options
-		data_len = 8192
+		data_len = options.data_len || 8192
 		msg = new Buffer(24+path.length+1)
 		htonl(msg, 0, 0) #version
 		htonl(msg, 4, path.length + 1) #payload length

--- a/src/owfs.coffee
+++ b/src/owfs.coffee
@@ -9,6 +9,7 @@ class Client
 		command =
 			path: path
 			command: fun
+			data_len: 8192
 			server: @server
 			port: @port
 		@communication.sendCommand(command, convert.extractDirectories(callback))
@@ -17,6 +18,7 @@ class Client
 		command =
 			path: path
 			command: 2
+			data_len: 8192
 			server: @server
 			port: @port
 		@communication.sendCommand(command, convert.extractValue(callback))
@@ -25,6 +27,7 @@ class Client
 		command =
 			path: path + "\u0000" + payload
 			command: 3
+			data_len: payload.toString().length
 			server: @server
 			port: @port
 		@communication.sendCommand(command, callback)


### PR DESCRIPTION
Write command always failed because of the fixed length 8192.
According to http://owfs.org/index.php?page=owserver-protocol size should contain the value length. I expanded options by data_len and fill this with the actual length of payload on send and with 8192 on read. Now writes also succeed!